### PR TITLE
fix: sanitize shell/subprocess call in run.py

### DIFF
--- a/selftest/run.py
+++ b/selftest/run.py
@@ -27,6 +27,7 @@ def log(status, msg):
 def run(cmd, **kwargs):
     kwargs.setdefault("capture_output", True)
     kwargs.setdefault("timeout", 300)
+    kwargs["shell"] = False  # Explicitly prevent shell injection
     return subprocess.run(cmd, **kwargs)
 
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `selftest/run.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-008 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-008` |
| **File** | `selftest/run.py:30` |
| **CWE** | CWE-78 |

**Description**: In selftest/run.py:30, subprocess.run(cmd, **kwargs) is called where cmd is passed from callers that may construct it from CLI arguments, environment variables, or configuration files. If cmd is constructed as a shell string with shell=True and includes user-controlled data, command injection is possible via shell metacharacters. The actual exploitability depends on whether shell=True is used and whether cmd incorporates unsanitized external input from callers at lines 674 and 811.

## Changes
- `selftest/run.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
